### PR TITLE
Additional Related Bug With This Branch

### DIFF
--- a/app/src/main/java/com/example/calculator/ArithmeticHandler.java
+++ b/app/src/main/java/com/example/calculator/ArithmeticHandler.java
@@ -72,6 +72,7 @@ public class ArithmeticHandler {
         }
 
         ArrayList<Integer> allClosedIndex = findAllIndexForString(expression, ")");
+        allClosedIndex.remove(Integer.valueOf(expression.size() - 1));
 
         int offsetClosed = 1;
         for (int i : allClosedIndex) {


### PR DESCRIPTION
An error would occur from going out of index if the expression ended with close parenthesis, this fixes that. This fix is an a related bug fix to this branch that wasn't caught in the previous rebase.

It now no longer adds a * for the last end parenthesis in an expression.
Fixes #20 