### PR TITLE
Error would occur from going out of index if last index close parenthesis

### DIFF
--- a/app/src/main/java/com/example/calculator/ArithmeticHandler.java
+++ b/app/src/main/java/com/example/calculator/ArithmeticHandler.java
@@ -72,6 +72,7 @@ public class ArithmeticHandler {
         }
 
         ArrayList<Integer> allClosedIndex = findAllIndexForString(expression, ")");
+        allClosedIndex.remove(Integer.valueOf(expression.size() - 1));
 
         int offsetClosed = 1;
         for (int i : allClosedIndex) {


### PR DESCRIPTION
This will fix that issue. It will no longer attempt implicit multiplication of parenthesis if it's the last value in the expression